### PR TITLE
Use C-unwind in bindgen, mandatory as of rust 1.81

### DIFF
--- a/crates/byondapi-macros/src/lib.rs
+++ b/crates/byondapi-macros/src/lib.rs
@@ -13,7 +13,7 @@ fn extract_args(a: &syn::FnArg) -> &syn::PatType {
 #[allow(clippy::test_attr_in_doctest)]
 /// Macro for generating byond binds
 /// Usage:
-/// ```
+/// ```ignore
 /// use byondapi::prelude::*;
 /// #[byondapi::bind]
 /// fn example() {Ok(ByondValue::null())}
@@ -23,7 +23,7 @@ fn extract_args(a: &syn::FnArg) -> &syn::PatType {
 ///
 /// ```
 /// Then generate the bindings.dm file with
-/// ```
+/// ```ignore
 /// #[test]
 /// fn generate_binds() {
 ///     byondapi::byondapi_macros::generate_bindings(env!("CARGO_CRATE_NAME"));

--- a/crates/byondapi-rs/Cargo.toml
+++ b/crates/byondapi-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "byondapi"
-version = "0.4.8"
+version = "0.4.9"
 authors = ["tigercat2000 <nick.pilant@gmail.com>"]
 edition = "2021"
 description = "Idiomatic Rust bindings for BYONDAPI"
@@ -13,7 +13,7 @@ exclude = [".vscode/*"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-byondapi-sys = { path = "../byondapi-sys", version = "0.11.1" }
+byondapi-sys = { path = "../byondapi-sys", version = "0.11.2" }
 byondapi-macros = { path = "../byondapi-macros", version = "0.1.2" }
 libloading = "0.8.4"
 inventory = "0.3.15"

--- a/crates/byondapi-rs/src/threadsync.rs
+++ b/crates/byondapi-rs/src/threadsync.rs
@@ -7,7 +7,9 @@ struct CallbackData<F: FnOnce() -> ByondValue + Send> {
     callback: Option<F>,
 }
 
-extern "C" fn trampoline<F: FnOnce() -> ByondValue + Send>(data: *mut c_void) -> CByondValue {
+extern "C-unwind" fn trampoline<F: FnOnce() -> ByondValue + Send>(
+    data: *mut c_void,
+) -> CByondValue {
     let data = unsafe { Box::from_raw(data as *mut CallbackData<F>) };
     (data.callback.unwrap())().into_inner()
 }

--- a/crates/byondapi-sys/Cargo.toml
+++ b/crates/byondapi-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "byondapi-sys"
-version = "0.11.1"
+version = "0.11.2"
 authors = ["tigercat2000 <nick.pilant@gmail.com>"]
 edition = "2021"
 description = "Raw bindgen bindings for byondapi"

--- a/crates/byondapi-sys/build.rs
+++ b/crates/byondapi-sys/build.rs
@@ -1,4 +1,4 @@
-use bindgen::callbacks::ParseCallbacks;
+use bindgen::{callbacks::ParseCallbacks, Abi};
 use std::path::{Path, PathBuf};
 
 fn main() {
@@ -55,6 +55,7 @@ fn generate_all() {
                 .header(wrapper.to_string_lossy())
                 .dynamic_library_name("ByondApi")
                 .dynamic_link_require_all(true)
+                .override_abi(Abi::CUnwind, "Byond.*")
                 // Also make headers included by main header dependencies of the build
                 .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
                 .parse_callbacks(Box::new(DoxygenCallbacks));


### PR DESCRIPTION
Rust 1.81 actually aborts the program if an unwind happens across an extern "C" boundary, see https://github.com/rust-lang/rust/pull/116088/

So it's important we actually do this correctly now, following meowtonin.