### PR TITLE
Fix 515.1621

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        feature_flags: [byond-515-1621, byond-516-1651]
         include:
           - os: ubuntu-latest
             target_name: i686-unknown-linux-gnu
@@ -39,7 +40,7 @@ jobs:
         with:
           toolchain: stable
           command: check
-          args: --target ${{ matrix.target_name }}
+          args: --target ${{ matrix.target_name }} --no-default-features --features ${{ matrix.feature_flags }}
 
   check_fmt:
     name: Check format

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,6 +13,7 @@ jobs:
     strategy:
       matrix:
         feature_flags: [byond-515-1621, byond-516-1651]
+        os: [ubuntu-latest, windows-latest]
         include:
           - os: ubuntu-latest
             target_name: i686-unknown-linux-gnu

--- a/crates/byondapi-rs-test/Cargo.toml
+++ b/crates/byondapi-rs-test/Cargo.toml
@@ -9,7 +9,12 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-byondapi = { path = "../byondapi-rs" }
+byondapi = { path = "../byondapi-rs", default-features = false }
 tempfile = "3.17.1"
 cargo_metadata = "0.19.1"
 eyre = "0.6.12"
+
+[features]
+default = ["byond-516-1651"]
+byond-515-1621 = ["byondapi/byond-515-1621",]
+byond-516-1651 = ["byondapi/byond-516-1651"]

--- a/crates/byondapi-rs/src/value/functions.rs
+++ b/crates/byondapi-rs/src/value/functions.rs
@@ -117,6 +117,7 @@ impl ByondValue {
 
     /// Replaces whatever is currently in this value with a string that's pointed to by the stringid
     /// # DO NOT PASS STRINGIDS THAT ARE NOT RETURNED BY [`crate::byond_string::str_id_of`]
+    #[cfg(feature = "byond-516-1651")]
     pub fn set_strid(&mut self, strid: u4c) {
         unsafe { byond().ByondValue_SetStrId(&mut self.0, strid) }
     }
@@ -249,6 +250,7 @@ impl ByondValue {
         unsafe { byond().ByondValue_DecRef(&self.0) }
     }
 
+    #[cfg(feature = "byond-516-1651")]
     pub fn decrement_tempref(&mut self) {
         unsafe { byond().ByondValue_DecTempRef(&self.0) }
     }


### PR DESCRIPTION
Currently get this error when building with the `byond-515-1621` feature.

```
error[E0599]: no method named `ByondValue_SetStrId` found for reference `&'static ByondApi` in the current scope
   --> C:\Users\AffectedArc07\.cargo\git\checkouts\byondapi-rs-6b86a2b778efd08c\8d16ff9\crates\byondapi-rs\src\value\functions.rs:121:26
    |
121 |         unsafe { byond().ByondValue_SetStrId(&mut self.0, strid) }
    |                          ^^^^^^^^^^^^^^^^^^^
    |
help: there is a method `ByondValue_SetStr` with a similar name
    |
121 |         unsafe { byond().ByondValue_SetStr(&mut self.0, strid) }
    |                          ~~~~~~~~~~~~~~~~~

error[E0599]: no method named `ByondValue_DecTempRef` found for reference `&'static ByondApi` in the current scope
   --> C:\Users\AffectedArc07\.cargo\git\checkouts\byondapi-rs-6b86a2b778efd08c\8d16ff9\crates\byondapi-rs\src\value\functions.rs:253:26
    |
253 |         unsafe { byond().ByondValue_DecTempRef(&self.0) }
    |                          ^^^^^^^^^^^^^^^^^^^^^
    |
help: there is a method `ByondValue_DecRef` with a similar name
    |
253 |         unsafe { byond().ByondValue_DecRef(&self.0) }
    |                          ~~~~~~~~~~~~~~~~~

For more information about this error, try `rustc --explain E0599`.
error: could not compile `byondapi` (lib) due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
```

Let me know what other stuff I need to bump please, first PR here

---

Also I made CI test compile both builds